### PR TITLE
[FEATURE] Add gitleaks CI snippet

### DIFF
--- a/CI/security/gitleaks.yml
+++ b/CI/security/gitleaks.yml
@@ -1,0 +1,33 @@
+gitleaks:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install gitleaks
+      run: |
+        GITLEAKS_VERSION="8.18.4"
+        BASE="https://github.com/gitleaks/gitleaks/releases/download"
+        FILE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        curl -sSfL "${BASE}/v${GITLEAKS_VERSION}/${FILE}" \
+          | tar -xz -C /usr/local/bin gitleaks
+
+    - name: Run gitleaks
+      run: |
+        set -euo pipefail
+
+        if ! command -v gitleaks &> /dev/null; then
+          echo "::error::gitleaks not found. Install it before running this script."
+          exit 1
+        fi
+
+        echo "ℹ️ Running gitleaks on the repository..."
+
+        if gitleaks detect --source . --no-banner --redact; then
+          echo "No secrets found"
+          exit 0
+        else
+          echo "gitleaks found potential secrets"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ that projects compose into their own workflows.
 
 | Tool | Category | File |
 |------|----------|------|
+| gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
 | ESLint | linters | [CI/linters/eslint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/eslint.yml) |
 | golangci-lint | linters | [CI/linters/golangci-lint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/golangci-lint.yml) |
 | Hadolint | linters | [CI/linters/hadolint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/hadolint.yml) |
@@ -78,6 +79,8 @@ Workflows/
 │   │   │   ├── stylelint.yml
 │   │   │   ├── swiftlint.yml
 │   │   │   └── yamllint.yml
+│   │   ├── security/
+│   │   │   └── gitleaks.yml
 │   │   ├── static_analysis/
 │   │   │   ├── mypy.yml
 │   │   │   ├── phpstan.yml
@@ -89,23 +92,26 @@ Workflows/
 │   │       ├── pytest.yml
 │   │       └── rspec.yml
 │   └── shell/                      # bash scripts (one per tool)
-│       └── linters/
-│           ├── eslint.sh
-│           ├── golangci-lint.sh
-│           ├── hadolint.sh
-│           ├── htmlhint.sh
-│           ├── ktlint.sh
-│           ├── markdownlint.sh
-│           ├── mermaid.sh
-│           ├── rubocop.sh
-│           ├── ruff.sh
-│           ├── shellcheck.sh
-│           ├── stylelint.sh
-│           ├── swiftlint.sh
-│           └── yamllint.sh
+│       ├── linters/
+│       │   ├── eslint.sh
+│       │   ├── golangci-lint.sh
+│       │   ├── hadolint.sh
+│       │   ├── htmlhint.sh
+│       │   ├── ktlint.sh
+│       │   ├── markdownlint.sh
+│       │   ├── mermaid.sh
+│       │   ├── rubocop.sh
+│       │   ├── ruff.sh
+│       │   ├── shellcheck.sh
+│       │   ├── stylelint.sh
+│       │   ├── swiftlint.sh
+│       │   └── yamllint.sh
+│       └── security/
+│           └── gitleaks.sh
 │
 ├── CI/                             # assembled output (ready to use)
 │   ├── linters/
+│   ├── security/
 │   ├── static_analysis/
 │   └── tests/
 │
@@ -118,6 +124,8 @@ Workflows/
 │   │   ├── shellcheck.bats
 │   │   ├── stylelint.bats
 │   │   └── yamllint.bats
+│   ├── security/
+│   │   └── gitleaks.bats
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
 │
@@ -137,6 +145,7 @@ Run the assembler for each category:
 
 ```bash
 bash scripts/assemble-ci.sh scripts/CI/linters        scripts/shell/linters        CI/linters
+bash scripts/assemble-ci.sh scripts/CI/security       scripts/shell/security       CI/security
 bash scripts/assemble-ci.sh scripts/CI/static_analysis scripts/shell/static_analysis CI/static_analysis
 bash scripts/assemble-ci.sh scripts/CI/tests           scripts/shell/tests           CI/tests
 ```
@@ -184,6 +193,12 @@ shellcheck:
 ---
 
 ## Available snippets
+
+### Security
+
+| Snippet | Tool | What it checks |
+|---------|------|----------------|
+| `CI/security/gitleaks.yml` | [gitleaks](https://github.com/gitleaks/gitleaks) | Hardcoded secrets, tokens, and API keys |
 
 ### Linters
 

--- a/scripts/CI/security/gitleaks.yml
+++ b/scripts/CI/security/gitleaks.yml
@@ -1,0 +1,17 @@
+gitleaks:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install gitleaks
+      run: |
+        GITLEAKS_VERSION="8.18.4"
+        BASE="https://github.com/gitleaks/gitleaks/releases/download"
+        FILE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        curl -sSfL "${BASE}/v${GITLEAKS_VERSION}/${FILE}" \
+          | tar -xz -C /usr/local/bin gitleaks
+
+    - name: Run gitleaks
+      run: bash scripts/shell/security/gitleaks.sh

--- a/scripts/shell/security/gitleaks.sh
+++ b/scripts/shell/security/gitleaks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gitleaks &> /dev/null; then
+  echo "::error::gitleaks not found. Install it before running this script."
+  exit 1
+fi
+
+echo "ℹ️ Running gitleaks on the repository..."
+
+if gitleaks detect --source . --no-banner --redact; then
+  echo "No secrets found"
+  exit 0
+else
+  echo "gitleaks found potential secrets"
+  exit 1
+fi

--- a/tests/security/gitleaks.bats
+++ b/tests/security/gitleaks.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/gitleaks.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_gitleaks_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/gitleaks" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/gitleaks"
+}
+
+@test "gitleaks not installed: exits 1 with error annotation" {
+  # Do not create a gitleaks stub — it should be absent from PATH
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::gitleaks not found"* ]]
+}
+
+@test "gitleaks finds no secrets: exits 0 with success message" {
+  make_gitleaks_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No secrets found"* ]]
+}
+
+@test "gitleaks finds secrets: exits 1 with failure message" {
+  make_gitleaks_stub 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gitleaks found potential secrets"* ]]
+}
+
+@test "scan message is printed before running gitleaks" {
+  make_gitleaks_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ℹ️ Running gitleaks on the repository"* ]]
+}


### PR DESCRIPTION
## Summary

Introduces a new `security` category to the CI library and adds the first snippet — gitleaks — a secrets scanner that detects hardcoded tokens, API keys, and passwords in source code and git history. The snippet follows the established three-layer pattern (shell script → source YAML → assembled YAML) and ships with BATS tests and README documentation.

## Changes

- issues-7|add gitleaks CI snippet (shell + source YAML + assembled YAML)
- issues-7|add BATS tests for gitleaks (4 tests, all passing)
- issues-7|document security category and gitleaks in README

## Test plan

- [x] `bats tests/security/gitleaks.bats` — 4/4 pass
- [x] `yamllint` clean on new YAML files
- [ ] CI green on this PR

Closes #7