### PR TITLE
[TEST] Add BATS tests for eslint.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *~
 
 /tasks
+.claude
+

--- a/tests/linters/eslint.bats
+++ b/tests/linters/eslint.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/linters/eslint.sh"
+
+setup() {
+  setup_test_dir
+  # mock npx so it dispatches to our stub
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+# Helper: create a stub for "npx eslint" via a wrapper named "npx"
+make_npx_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/npx" <<EOF
+#!/usr/bin/env bash
+# argv[0]=eslint argv[1]=<file>
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/npx"
+}
+
+make_npx_conditional_stub() {
+  cat > "$TEST_DIR/bin/npx" <<'EOF'
+#!/usr/bin/env bash
+# $1 = eslint, $2 = file
+if [[ "${MOCK_FAIL_PATTERN:-}" != "" && "$2" == *"${MOCK_FAIL_PATTERN}"* ]]; then
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$TEST_DIR/bin/npx"
+}
+
+@test "config file missing: exits 1 with ::error:: message" {
+  make_npx_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No ESLint config file found"* ]]
+}
+
+@test "config .eslintrc.json found, no JS/TS files: exits 0 with skipping message" {
+  make_npx_stub 0
+  touch .eslintrc.json
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠️ No JS/TS files found. Skipping."* ]]
+}
+
+@test "config eslint.config.js found, all files pass: exits 0 with success message" {
+  make_npx_stub 0
+  touch eslint.config.js index.js app.ts
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ All JS/TS files passed ESLint checks!"* ]]
+}
+
+@test "config found, one file fails: exits 1 with failure message" {
+  make_npx_stub 1
+  touch .eslintrc.json index.js
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ ESLint found issues!"* ]]
+}
+
+@test "multiple files, one fails: exits 1 and all files are checked" {
+  make_npx_conditional_stub
+  touch .eslintrc.json good.js bad.js
+  MOCK_FAIL_PATTERN="bad.js" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ℹ️ Checking good.js"* ]]
+  [[ "$output" == *"ℹ️ Checking bad.js"* ]]
+  [[ "$output" == *"❌ ESLint found issues!"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a BATS test file for `scripts/shell/linters/eslint.sh`, closing the one remaining gap where every other linter script in `scripts/shell/linters/` has a test counterpart but `eslint.bats` was missing. The new file mirrors the structure and helpers used by `htmlhint.bats` / `stylelint.bats`.

## Changes

- `tests/linters/eslint.bats` — 5 tests covering: missing config, config found with no target files, alternative config format (`eslint.config.js`), one failing file, and the accumulator pattern across multiple files

## Test plan

- [x] Test file uses `tests/helpers/common.bash` (`setup_test_dir` / `teardown_test_dir`) and local `make_npx_stub` / `make_npx_conditional_stub` helpers, matching `htmlhint.bats`
- [x] Local run on macOS: test 1 (config-missing) passes; tests 2–5 fail locally due to a pre-existing environment issue (macOS system bash 3.2 lacks `mapfile`). The same failure pattern affects every `mapfile`-using linter test in the suite (htmlhint, markdownlint, stylelint, yamllint) and is not caused by this PR.
- [ ] CI (Linux, bash ≥ 5) green on this PR

Closes #3