### PR TITLE
[FEATURE] Add Trivy CI snippet

### DIFF
--- a/CI/security/trivy.yml
+++ b/CI/security/trivy.yml
@@ -1,0 +1,37 @@
+trivy:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Trivy DB
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/trivy
+        key: trivy-db-${{ runner.os }}
+
+    - name: Install Trivy
+      run: |
+        TRIVY_VERSION="0.61.0"
+        BASE="https://github.com/aquasecurity/trivy/releases/download"
+        FILE="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -sSfL "${BASE}/v${TRIVY_VERSION}/${FILE}" \
+          | tar -xz -C /usr/local/bin trivy
+
+    - name: Run Trivy
+      run: |
+        set -euo pipefail
+
+        if ! command -v trivy &> /dev/null; then
+          echo "::error::trivy not found. Install it before running this script."
+          exit 1
+        fi
+
+        echo "ℹ️ Running Trivy filesystem scan..."
+
+        if trivy fs --exit-code 1 --severity HIGH,CRITICAL --no-progress .; then
+          echo "✅ No HIGH/CRITICAL vulnerabilities"
+          exit 0
+        else
+          echo "❌ Trivy found HIGH/CRITICAL vulnerabilities"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ that projects compose into their own workflows.
 | Tool | Category | File |
 |------|----------|------|
 | gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
+| trivy | security | [CI/security/trivy.yml](https://github.com/prog-time/workflows/blob/main/CI/security/trivy.yml) |
 | ESLint | linters | [CI/linters/eslint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/eslint.yml) |
 | golangci-lint | linters | [CI/linters/golangci-lint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/golangci-lint.yml) |
 | Hadolint | linters | [CI/linters/hadolint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/hadolint.yml) |
@@ -80,7 +81,8 @@ Workflows/
 │   │   │   ├── swiftlint.yml
 │   │   │   └── yamllint.yml
 │   │   ├── security/
-│   │   │   └── gitleaks.yml
+│   │   │   ├── gitleaks.yml
+│   │   │   └── trivy.yml
 │   │   ├── static_analysis/
 │   │   │   ├── mypy.yml
 │   │   │   ├── phpstan.yml
@@ -107,7 +109,8 @@ Workflows/
 │       │   ├── swiftlint.sh
 │       │   └── yamllint.sh
 │       └── security/
-│           └── gitleaks.sh
+│           ├── gitleaks.sh
+│           └── trivy.sh
 │
 ├── CI/                             # assembled output (ready to use)
 │   ├── linters/
@@ -125,7 +128,8 @@ Workflows/
 │   │   ├── stylelint.bats
 │   │   └── yamllint.bats
 │   ├── security/
-│   │   └── gitleaks.bats
+│   │   ├── gitleaks.bats
+│   │   └── trivy.bats
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
 │
@@ -199,6 +203,7 @@ shellcheck:
 | Snippet | Tool | What it checks |
 |---------|------|----------------|
 | `CI/security/gitleaks.yml` | [gitleaks](https://github.com/gitleaks/gitleaks) | Hardcoded secrets, tokens, and API keys |
+| `CI/security/trivy.yml` | [trivy](https://github.com/aquasecurity/trivy) | CVEs in OS packages, container images, and dependency manifests |
 
 ### Linters
 

--- a/scripts/CI/security/trivy.yml
+++ b/scripts/CI/security/trivy.yml
@@ -1,0 +1,21 @@
+trivy:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Trivy DB
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/trivy
+        key: trivy-db-${{ runner.os }}
+
+    - name: Install Trivy
+      run: |
+        TRIVY_VERSION="0.61.0"
+        BASE="https://github.com/aquasecurity/trivy/releases/download"
+        FILE="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        curl -sSfL "${BASE}/v${TRIVY_VERSION}/${FILE}" \
+          | tar -xz -C /usr/local/bin trivy
+
+    - name: Run Trivy
+      run: bash scripts/shell/security/trivy.sh

--- a/scripts/shell/security/trivy.sh
+++ b/scripts/shell/security/trivy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v trivy &> /dev/null; then
+  echo "::error::trivy not found. Install it before running this script."
+  exit 1
+fi
+
+echo "ℹ️ Running Trivy filesystem scan..."
+
+if trivy fs --exit-code 1 --severity HIGH,CRITICAL --no-progress .; then
+  echo "✅ No HIGH/CRITICAL vulnerabilities"
+  exit 0
+else
+  echo "❌ Trivy found HIGH/CRITICAL vulnerabilities"
+  exit 1
+fi

--- a/tests/security/trivy.bats
+++ b/tests/security/trivy.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/trivy.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_trivy_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/trivy" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/trivy"
+}
+
+@test "trivy not installed: exits 1 with error annotation" {
+  # Do not create a trivy stub — it should be absent from PATH
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::trivy not found"* ]]
+}
+
+@test "trivy finds no vulnerabilities: exits 0 with success message" {
+  make_trivy_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ No HIGH/CRITICAL vulnerabilities"* ]]
+}
+
+@test "trivy finds vulnerabilities: exits 1 with failure message" {
+  make_trivy_stub 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ Trivy found HIGH/CRITICAL vulnerabilities"* ]]
+}
+
+@test "scan message is printed before running trivy" {
+  make_trivy_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ℹ️ Running Trivy filesystem scan"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a Trivy CI snippet to the `security` category — a universal vulnerability scanner covering filesystem, container images, and language-specific dependency manifests (npm, pip, go.mod, Gemfile.lock, composer.lock, Cargo.lock). Follows the three-layer pattern (shell script → source YAML → assembled YAML) established by gitleaks, with `actions/cache@v4` for `~/.cache/trivy` to avoid redundant DB downloads.

## Changes

- `issues-8|add trivy CI snippet` — `scripts/shell/security/trivy.sh`, `scripts/CI/security/trivy.yml`, `CI/security/trivy.yml`
- `issues-8|add BATS tests for trivy` — 4 tests (missing binary, clean scan, vulnerable scan, info message)
- `issues-8|document trivy in README` — Snippets table, Security section, project structure tree

## Test plan

- [x] `bats tests/security/trivy.bats` — 4/4 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #8