### PR TITLE
[FEATURE] Add Semgrep CI snippet

### DIFF
--- a/CI/security/semgrep.yml
+++ b/CI/security/semgrep.yml
@@ -1,0 +1,36 @@
+semgrep:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Cache Semgrep
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/semgrep
+        key: semgrep-${{ runner.os }}-${{ hashFiles('**/.semgrepignore') }}
+
+    - name: Install Semgrep
+      run: pip install semgrep==1.72.0
+
+    - name: Run Semgrep
+      run: |
+        set -euo pipefail
+
+        if ! command -v semgrep &> /dev/null; then
+          echo "::error::semgrep not found. Install it before running this script."
+          exit 1
+        fi
+
+        echo "ℹ️ Running Semgrep static analysis..."
+
+        if semgrep --config p/default --error .; then
+          echo "✅ Semgrep passed"
+          exit 0
+        else
+          echo "❌ Semgrep found issues"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ that projects compose into their own workflows.
 |------|----------|------|
 | gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
 | trivy | security | [CI/security/trivy.yml](https://github.com/prog-time/workflows/blob/main/CI/security/trivy.yml) |
+| semgrep | security | [CI/security/semgrep.yml](https://github.com/prog-time/workflows/blob/main/CI/security/semgrep.yml) |
 | ESLint | linters | [CI/linters/eslint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/eslint.yml) |
 | golangci-lint | linters | [CI/linters/golangci-lint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/golangci-lint.yml) |
 | Hadolint | linters | [CI/linters/hadolint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/hadolint.yml) |
@@ -82,6 +83,7 @@ Workflows/
 │   │   │   └── yamllint.yml
 │   │   ├── security/
 │   │   │   ├── gitleaks.yml
+│   │   │   ├── semgrep.yml
 │   │   │   └── trivy.yml
 │   │   ├── static_analysis/
 │   │   │   ├── mypy.yml
@@ -110,6 +112,7 @@ Workflows/
 │       │   └── yamllint.sh
 │       └── security/
 │           ├── gitleaks.sh
+│           ├── semgrep.sh
 │           └── trivy.sh
 │
 ├── CI/                             # assembled output (ready to use)
@@ -129,6 +132,7 @@ Workflows/
 │   │   └── yamllint.bats
 │   ├── security/
 │   │   ├── gitleaks.bats
+│   │   ├── semgrep.bats
 │   │   └── trivy.bats
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
@@ -204,6 +208,7 @@ shellcheck:
 |---------|------|----------------|
 | `CI/security/gitleaks.yml` | [gitleaks](https://github.com/gitleaks/gitleaks) | Hardcoded secrets, tokens, and API keys |
 | `CI/security/trivy.yml` | [trivy](https://github.com/aquasecurity/trivy) | CVEs in OS packages, container images, and dependency manifests |
+| `CI/security/semgrep.yml` | [semgrep](https://semgrep.dev) | OWASP Top 10 patterns and insecure coding patterns across Python, JS/TS, Go, Java, Ruby, and more |
 
 ### Linters
 

--- a/scripts/CI/security/semgrep.yml
+++ b/scripts/CI/security/semgrep.yml
@@ -1,0 +1,20 @@
+semgrep:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Cache Semgrep
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/semgrep
+        key: semgrep-${{ runner.os }}-${{ hashFiles('**/.semgrepignore') }}
+
+    - name: Install Semgrep
+      run: pip install semgrep==1.72.0
+
+    - name: Run Semgrep
+      run: bash scripts/shell/security/semgrep.sh

--- a/scripts/shell/security/semgrep.sh
+++ b/scripts/shell/security/semgrep.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v semgrep &> /dev/null; then
+  echo "::error::semgrep not found. Install it before running this script."
+  exit 1
+fi
+
+echo "ℹ️ Running Semgrep static analysis..."
+
+if semgrep --config p/default --error .; then
+  echo "✅ Semgrep passed"
+  exit 0
+else
+  echo "❌ Semgrep found issues"
+  exit 1
+fi

--- a/tests/security/semgrep.bats
+++ b/tests/security/semgrep.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/semgrep.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_semgrep_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/semgrep" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/semgrep"
+}
+
+@test "semgrep not installed: exits 1 with error annotation" {
+  # Do not create a semgrep stub — it should be absent from PATH
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::semgrep not found"* ]]
+}
+
+@test "semgrep finds no issues: exits 0 with success message" {
+  make_semgrep_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ Semgrep passed"* ]]
+}
+
+@test "semgrep finds issues: exits 1 with failure message" {
+  make_semgrep_stub 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ Semgrep found issues"* ]]
+}
+
+@test "scan message is printed before running semgrep" {
+  make_semgrep_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ℹ️ Running Semgrep static analysis"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a Semgrep CI snippet to the `security` category — a multi-language SAST tool running the `p/default` ruleset (OWASP Top 10). Complements PHPStan / mypy / SpotBugs (type/bug checkers) with a security-focused rule layer across Python, JS/TS, Go, Java, Ruby, PHP and more in one configuration.

## Changes

- `issues-9|add semgrep CI snippet` — `scripts/shell/security/semgrep.sh`, `scripts/CI/security/semgrep.yml`, `CI/security/semgrep.yml`
- `issues-9|add BATS tests for semgrep` — 4 tests (missing binary, clean scan, failing scan, info message)
- `issues-9|document semgrep in README` — Snippets table, Security section, project structure tree

## Test plan

- [x] `bats tests/security/semgrep.bats` — 4/4 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #9