### PR TITLE
[FEATURE] Add SQLFluff CI snippet

### DIFF
--- a/CI/linters/sqlfluff.yml
+++ b/CI/linters/sqlfluff.yml
@@ -1,0 +1,48 @@
+sqlfluff:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install SQLFluff
+      run: pip install sqlfluff==3.4.1
+
+    - name: Run SQLFluff on SQL files
+      run: |
+        set -euo pipefail
+
+        # Config detection: .sqlfluff, pyproject.toml with [tool.sqlfluff], or setup.cfg with sqlfluff section
+        CONFIG_FOUND=0
+
+        if [[ -f ".sqlfluff" ]]; then
+          CONFIG_FOUND=1
+        elif [[ -f "pyproject.toml" ]] && grep -q '\[tool\.sqlfluff\]' pyproject.toml; then
+          CONFIG_FOUND=1
+        elif [[ -f "setup.cfg" ]] && grep -q '\[sqlfluff\]' setup.cfg; then
+          CONFIG_FOUND=1
+        fi
+
+        if [[ $CONFIG_FOUND -eq 0 ]]; then
+          echo "::error::No SQLFluff config found (.sqlfluff, pyproject.toml [tool.sqlfluff], or setup.cfg [sqlfluff])"
+          exit 1
+        fi
+
+        SQL_COUNT=$(find . -type f -name "*.sql" \
+          -not -path "./node_modules/*" \
+          -not -path "./.git/*" \
+          -not -path "./_site/*" | wc -l | tr -d ' ')
+
+        if [[ "$SQL_COUNT" -eq 0 ]]; then
+          echo "⚠️ No SQL files found. Skipping."
+          exit 0
+        fi
+
+        if sqlfluff lint .; then
+          echo "✅ SQLFluff passed"
+        else
+          echo "❌ SQLFluff found issues"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ that projects compose into their own workflows.
 | RuboCop | linters | [CI/linters/rubocop.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/rubocop.yml) |
 | Ruff | linters | [CI/linters/ruff.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/ruff.yml) |
 | ShellCheck | linters | [CI/linters/shellcheck.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/shellcheck.yml) |
+| SQLFluff | linters | [CI/linters/sqlfluff.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/sqlfluff.yml) |
 | Stylelint | linters | [CI/linters/stylelint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/stylelint.yml) |
 | SwiftLint | linters | [CI/linters/swiftlint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/swiftlint.yml) |
 | yamllint | linters | [CI/linters/yamllint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/yamllint.yml) |
@@ -83,6 +84,7 @@ Workflows/
 │   │   │   ├── rubocop.yml
 │   │   │   ├── ruff.yml
 │   │   │   ├── shellcheck.yml
+│   │   │   ├── sqlfluff.yml
 │   │   │   ├── stylelint.yml
 │   │   │   ├── swiftlint.yml
 │   │   │   └── yamllint.yml
@@ -115,6 +117,7 @@ Workflows/
 │       │   ├── rubocop.sh
 │       │   ├── ruff.sh
 │       │   ├── shellcheck.sh
+│       │   ├── sqlfluff.sh
 │       │   ├── stylelint.sh
 │       │   ├── swiftlint.sh
 │       │   └── yamllint.sh
@@ -140,6 +143,7 @@ Workflows/
 │   │   ├── markdownlint.bats
 │   │   ├── phpcs.bats
 │   │   ├── shellcheck.bats
+│   │   ├── sqlfluff.bats
 │   │   ├── stylelint.bats
 │   │   └── yamllint.bats
 │   ├── security/
@@ -240,6 +244,7 @@ shellcheck:
 | `CI/linters/rubocop.yml` | [rubocop](https://rubocop.org) | Ruby |
 | `CI/linters/ruff.yml` | [ruff](https://docs.astral.sh/ruff) | Python |
 | `CI/linters/shellcheck.yml` | [shellcheck](https://www.shellcheck.net) | Shell scripts |
+| `CI/linters/sqlfluff.yml` | [sqlfluff](https://sqlfluff.com) | SQL files |
 | `CI/linters/stylelint.yml` | [stylelint](https://stylelint.io) | CSS / SCSS / LESS |
 | `CI/linters/swiftlint.yml` | [swiftlint](https://realm.github.io/SwiftLint) | Swift |
 | `CI/linters/yamllint.yml` | [yamllint](https://yamllint.readthedocs.io) | YAML files |

--- a/scripts/CI/linters/sqlfluff.yml
+++ b/scripts/CI/linters/sqlfluff.yml
@@ -1,0 +1,14 @@
+sqlfluff:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install SQLFluff
+      run: pip install sqlfluff==3.4.1
+
+    - name: Run SQLFluff on SQL files
+      run: bash scripts/shell/linters/sqlfluff.sh

--- a/scripts/shell/linters/sqlfluff.sh
+++ b/scripts/shell/linters/sqlfluff.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Config detection: .sqlfluff, pyproject.toml with [tool.sqlfluff], or setup.cfg with sqlfluff section
+CONFIG_FOUND=0
+
+if [[ -f ".sqlfluff" ]]; then
+  CONFIG_FOUND=1
+elif [[ -f "pyproject.toml" ]] && grep -q '\[tool\.sqlfluff\]' pyproject.toml; then
+  CONFIG_FOUND=1
+elif [[ -f "setup.cfg" ]] && grep -q '\[sqlfluff\]' setup.cfg; then
+  CONFIG_FOUND=1
+fi
+
+if [[ $CONFIG_FOUND -eq 0 ]]; then
+  echo "::error::No SQLFluff config found (.sqlfluff, pyproject.toml [tool.sqlfluff], or setup.cfg [sqlfluff])"
+  exit 1
+fi
+
+SQL_COUNT=$(find . -type f -name "*.sql" \
+  -not -path "./node_modules/*" \
+  -not -path "./.git/*" \
+  -not -path "./_site/*" | wc -l | tr -d ' ')
+
+if [[ "$SQL_COUNT" -eq 0 ]]; then
+  echo "⚠️ No SQL files found. Skipping."
+  exit 0
+fi
+
+if sqlfluff lint .; then
+  echo "✅ SQLFluff passed"
+else
+  echo "❌ SQLFluff found issues"
+  exit 1
+fi

--- a/tests/linters/sqlfluff.bats
+++ b/tests/linters/sqlfluff.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/linters/sqlfluff.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_sqlfluff_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/sqlfluff" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/sqlfluff"
+}
+
+@test "no config found: exits 1 with error annotation" {
+  make_sqlfluff_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No SQLFluff config found"* ]]
+}
+
+@test "config present, no SQL files: exits 0 with skip message" {
+  make_sqlfluff_stub 0
+  touch .sqlfluff
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠️ No SQL files found. Skipping."* ]]
+}
+
+@test "config present, SQL files pass: exits 0 with success message" {
+  make_sqlfluff_stub 0
+  touch .sqlfluff migration.sql
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ SQLFluff passed"* ]]
+}
+
+@test "config present, SQL files fail: exits 1 with failure message" {
+  make_sqlfluff_stub 1
+  touch .sqlfluff migration.sql
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ SQLFluff found issues"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a SQLFluff CI snippet to the `linters` category — catches dialect-specific syntax errors and style issues (keyword casing, indentation, ambiguous column references) across Postgres, MySQL, Snowflake, BigQuery and others. Config detection covers `.sqlfluff`, `[tool.sqlfluff]` in `pyproject.toml`, or `setup.cfg`. Uses `actions/setup-python@v5` + pinned `sqlfluff==3.4.1`.

## Changes

- `issues-13|add sqlfluff CI snippet` — `scripts/shell/linters/sqlfluff.sh`, `scripts/CI/linters/sqlfluff.yml`, `CI/linters/sqlfluff.yml`
- `issues-13|add BATS tests for sqlfluff` — 4 tests (missing config, no SQL files, clean, violation)
- `issues-13|document sqlfluff in README` — Snippets table, Available snippets / Linters section, project structure tree

## Test plan

- [x] `bats tests/linters/sqlfluff.bats` — 4/4 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #13