### PR TITLE
[FEATURE] Add tflint CI snippet

### DIFF
--- a/CI/linters/tflint.yml
+++ b/CI/linters/tflint.yml
@@ -1,0 +1,35 @@
+tflint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: terraform-linters/setup-tflint@v4
+      with:
+        tflint_version: v0.55.0
+
+    - name: Run tflint on Terraform files
+      run: |
+        set -euo pipefail
+
+        if ! command -v tflint > /dev/null 2>&1; then
+          echo "::error::tflint is not installed or not in PATH"
+          exit 1
+        fi
+
+        TF_COUNT=$(find . -type f -name "*.tf" \
+          -not -path "./.git/*" \
+          -not -path "./.terraform/*" | wc -l | tr -d ' ')
+
+        if [[ "$TF_COUNT" -eq 0 ]]; then
+          echo "⚠️ No Terraform files found. Skipping."
+          exit 0
+        fi
+
+        tflint --init
+
+        if tflint --recursive; then
+          echo "✅ tflint passed"
+        else
+          echo "❌ tflint found issues"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ that projects compose into their own workflows.
 | SQLFluff | linters | [CI/linters/sqlfluff.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/sqlfluff.yml) |
 | Stylelint | linters | [CI/linters/stylelint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/stylelint.yml) |
 | SwiftLint | linters | [CI/linters/swiftlint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/swiftlint.yml) |
+| tflint | linters | [CI/linters/tflint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/tflint.yml) |
 | yamllint | linters | [CI/linters/yamllint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/yamllint.yml) |
 | mypy | static_analysis | [CI/static_analysis/mypy.yml](https://github.com/prog-time/workflows/blob/main/CI/static_analysis/mypy.yml) |
 | PHPStan | static_analysis | [CI/static_analysis/phpstan.yml](https://github.com/prog-time/workflows/blob/main/CI/static_analysis/phpstan.yml) |
@@ -87,6 +88,7 @@ Workflows/
 │   │   │   ├── sqlfluff.yml
 │   │   │   ├── stylelint.yml
 │   │   │   ├── swiftlint.yml
+│   │   │   ├── tflint.yml
 │   │   │   └── yamllint.yml
 │   │   ├── security/
 │   │   │   ├── gitleaks.yml
@@ -120,6 +122,7 @@ Workflows/
 │       │   ├── sqlfluff.sh
 │       │   ├── stylelint.sh
 │       │   ├── swiftlint.sh
+│       │   ├── tflint.sh
 │       │   └── yamllint.sh
 │       ├── security/
 │       │   ├── gitleaks.sh
@@ -145,6 +148,7 @@ Workflows/
 │   │   ├── shellcheck.bats
 │   │   ├── sqlfluff.bats
 │   │   ├── stylelint.bats
+│   │   ├── tflint.bats
 │   │   └── yamllint.bats
 │   ├── security/
 │   │   ├── gitleaks.bats
@@ -247,6 +251,7 @@ shellcheck:
 | `CI/linters/sqlfluff.yml` | [sqlfluff](https://sqlfluff.com) | SQL files |
 | `CI/linters/stylelint.yml` | [stylelint](https://stylelint.io) | CSS / SCSS / LESS |
 | `CI/linters/swiftlint.yml` | [swiftlint](https://realm.github.io/SwiftLint) | Swift |
+| `CI/linters/tflint.yml` | [tflint](https://github.com/terraform-linters/tflint) | Terraform |
 | `CI/linters/yamllint.yml` | [yamllint](https://yamllint.readthedocs.io) | YAML files |
 
 ### Static analysis

--- a/scripts/CI/linters/tflint.yml
+++ b/scripts/CI/linters/tflint.yml
@@ -1,0 +1,11 @@
+tflint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: terraform-linters/setup-tflint@v4
+      with:
+        tflint_version: v0.55.0
+
+    - name: Run tflint on Terraform files
+      run: bash scripts/shell/linters/tflint.sh

--- a/scripts/shell/linters/tflint.sh
+++ b/scripts/shell/linters/tflint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v tflint > /dev/null 2>&1; then
+  echo "::error::tflint is not installed or not in PATH"
+  exit 1
+fi
+
+TF_COUNT=$(find . -type f -name "*.tf" \
+  -not -path "./.git/*" \
+  -not -path "./.terraform/*" | wc -l | tr -d ' ')
+
+if [[ "$TF_COUNT" -eq 0 ]]; then
+  echo "⚠️ No Terraform files found. Skipping."
+  exit 0
+fi
+
+tflint --init
+
+if tflint --recursive; then
+  echo "✅ tflint passed"
+else
+  echo "❌ tflint found issues"
+  exit 1
+fi

--- a/tests/linters/tflint.bats
+++ b/tests/linters/tflint.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/linters/tflint.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_tflint_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/tflint" <<EOF
+#!/usr/bin/env bash
+# --init always succeeds; --recursive exits with the configured code
+for arg in "\$@"; do
+  if [[ "\$arg" == "--recursive" ]]; then
+    exit $exit_code
+  fi
+done
+exit 0
+EOF
+  chmod +x "$TEST_DIR/bin/tflint"
+}
+
+@test "no Terraform files: exits 0 with skip message" {
+  make_tflint_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠️ No Terraform files found. Skipping."* ]]
+}
+
+@test "Terraform files present, tflint passes: exits 0 with success message" {
+  make_tflint_stub 0
+  touch main.tf
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ tflint passed"* ]]
+}
+
+@test "Terraform files present, tflint finds issues: exits 1 with failure message" {
+  make_tflint_stub 1
+  touch main.tf
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ tflint found issues"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a tflint CI snippet to the `linters` category — Terraform linter catching deprecated syntax, provider-specific errors, and module-structure issues that `terraform validate` misses. Uses the official `terraform-linters/setup-tflint@v4` action (tflint v0.55.0 pinned). Runs `tflint --init` then `tflint --recursive`; gracefully skips when no `.tf` files are present.

## Changes

- `issues-14|add tflint CI snippet` — `scripts/shell/linters/tflint.sh`, `scripts/CI/linters/tflint.yml`, `CI/linters/tflint.yml`
- `issues-14|add BATS tests for tflint` — 3 tests (no `.tf`, clean, failing)
- `issues-14|document tflint in README` — Snippets table, Available snippets / Linters section, project structure tree

## Test plan

- [x] `bats tests/linters/tflint.bats` — 3/3 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #14