### PR TITLE
[FEATURE] Add pip-audit CI snippet

### DIFF
--- a/CI/security/pip-audit.yml
+++ b/CI/security/pip-audit.yml
@@ -1,0 +1,44 @@
+pip-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install pip-audit
+      run: pip install pip-audit==2.7.3
+
+    - name: Run pip-audit
+      run: |
+        set -euo pipefail
+
+        if ! command -v pip-audit &> /dev/null; then
+          echo "::error::pip-audit not found. Install it before running this script."
+          exit 1
+        fi
+
+        REQ_FILE=""
+        if [[ -f "requirements.txt" ]]; then
+          REQ_FILE="requirements.txt"
+        elif [[ -f "pyproject.toml" ]]; then
+          REQ_FILE="pyproject.toml"
+        elif [[ -f "Pipfile.lock" ]]; then
+          REQ_FILE="Pipfile.lock"
+        fi
+
+        if [[ -z "$REQ_FILE" ]]; then
+          echo "::error::No Python requirements file found (requirements.txt, pyproject.toml, or Pipfile.lock)."
+          exit 1
+        fi
+
+        echo "ℹ️ Running pip-audit on $REQ_FILE..."
+
+        if [[ "$REQ_FILE" == "requirements.txt" ]]; then
+          pip-audit --strict -r requirements.txt
+        else
+          pip-audit --strict
+        fi
+
+        echo "✅ pip-audit passed"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ that projects compose into their own workflows.
 | Tool | Category | File |
 |------|----------|------|
 | gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
-| trivy | security | [CI/security/trivy.yml](https://github.com/prog-time/workflows/blob/main/CI/security/trivy.yml) |
+| pip-audit | security | [CI/security/pip-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/pip-audit.yml) |
 | semgrep | security | [CI/security/semgrep.yml](https://github.com/prog-time/workflows/blob/main/CI/security/semgrep.yml) |
+| trivy | security | [CI/security/trivy.yml](https://github.com/prog-time/workflows/blob/main/CI/security/trivy.yml) |
 | Clippy | linters | [CI/linters/clippy.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/clippy.yml) |
 | ESLint | linters | [CI/linters/eslint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/eslint.yml) |
 | golangci-lint | linters | [CI/linters/golangci-lint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/golangci-lint.yml) |
@@ -92,6 +93,7 @@ Workflows/
 │   │   │   └── yamllint.yml
 │   │   ├── security/
 │   │   │   ├── gitleaks.yml
+│   │   │   ├── pip-audit.yml
 │   │   │   ├── semgrep.yml
 │   │   │   └── trivy.yml
 │   │   ├── static_analysis/
@@ -126,6 +128,7 @@ Workflows/
 │       │   └── yamllint.sh
 │       ├── security/
 │       │   ├── gitleaks.sh
+│       │   ├── pip-audit.sh
 │       │   ├── semgrep.sh
 │       │   └── trivy.sh
 │       └── tests/
@@ -152,6 +155,7 @@ Workflows/
 │   │   └── yamllint.bats
 │   ├── security/
 │   │   ├── gitleaks.bats
+│   │   ├── pip-audit.bats
 │   │   ├── semgrep.bats
 │   │   └── trivy.bats
 │   ├── tests/
@@ -229,8 +233,9 @@ shellcheck:
 | Snippet | Tool | What it checks |
 |---------|------|----------------|
 | `CI/security/gitleaks.yml` | [gitleaks](https://github.com/gitleaks/gitleaks) | Hardcoded secrets, tokens, and API keys |
-| `CI/security/trivy.yml` | [trivy](https://github.com/aquasecurity/trivy) | CVEs in OS packages, container images, and dependency manifests |
+| `CI/security/pip-audit.yml` | [pip-audit](https://github.com/pypa/pip-audit) | CVEs in Python dependencies via the PyPI Advisory Database |
 | `CI/security/semgrep.yml` | [semgrep](https://semgrep.dev) | OWASP Top 10 patterns and insecure coding patterns across Python, JS/TS, Go, Java, Ruby, and more |
+| `CI/security/trivy.yml` | [trivy](https://github.com/aquasecurity/trivy) | CVEs in OS packages, container images, and dependency manifests |
 
 ### Linters
 

--- a/scripts/CI/security/pip-audit.yml
+++ b/scripts/CI/security/pip-audit.yml
@@ -1,0 +1,14 @@
+pip-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install pip-audit
+      run: pip install pip-audit==2.7.3
+
+    - name: Run pip-audit
+      run: bash scripts/shell/security/pip-audit.sh

--- a/scripts/shell/security/pip-audit.sh
+++ b/scripts/shell/security/pip-audit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v pip-audit &> /dev/null; then
+  echo "::error::pip-audit not found. Install it before running this script."
+  exit 1
+fi
+
+REQ_FILE=""
+if [[ -f "requirements.txt" ]]; then
+  REQ_FILE="requirements.txt"
+elif [[ -f "pyproject.toml" ]]; then
+  REQ_FILE="pyproject.toml"
+elif [[ -f "Pipfile.lock" ]]; then
+  REQ_FILE="Pipfile.lock"
+fi
+
+if [[ -z "$REQ_FILE" ]]; then
+  echo "::error::No Python requirements file found (requirements.txt, pyproject.toml, or Pipfile.lock)."
+  exit 1
+fi
+
+echo "ℹ️ Running pip-audit on $REQ_FILE..."
+
+if [[ "$REQ_FILE" == "requirements.txt" ]]; then
+  pip-audit --strict -r requirements.txt
+else
+  pip-audit --strict
+fi
+
+echo "✅ pip-audit passed"

--- a/tests/security/pip-audit.bats
+++ b/tests/security/pip-audit.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/pip-audit.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_pip_audit_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/pip-audit" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/pip-audit"
+}
+
+@test "pip-audit not installed: exits 1 with error annotation" {
+  # Do not create a pip-audit stub — it should be absent from PATH
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::pip-audit not found"* ]]
+}
+
+@test "no requirements file present: exits 1 with error annotation" {
+  make_pip_audit_stub 0
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No Python requirements file found"* ]]
+}
+
+@test "clean requirements.txt: exits 0 with success message" {
+  make_pip_audit_stub 0
+  echo "requests==2.31.0" > "$TEST_DIR/requirements.txt"
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ pip-audit passed"* ]]
+}
+
+@test "vulnerable pin in requirements.txt: exits 1 with failure message" {
+  make_pip_audit_stub 1
+  echo "django==2.2.0" > "$TEST_DIR/requirements.txt"
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"✅ pip-audit passed"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a pip-audit CI snippet to the `security` category — PyPA's dependency vulnerability scanner that integrates with the PyPI Advisory Database and understands `requirements.txt`, `pyproject.toml`, and `Pipfile.lock` natively. Complements Trivy's broader filesystem scan for Python-specific cases (editable installs, hash-pinned requirements).

## Changes

- `issues-15|add pip-audit CI snippet` — `scripts/shell/security/pip-audit.sh`, `scripts/CI/security/pip-audit.yml`, `CI/security/pip-audit.yml`
- `issues-15|add BATS tests for pip-audit` — 4 tests (missing binary, no requirements file, clean, vulnerable pin)
- `issues-15|document pip-audit in README` — Snippets table, Available snippets / Security section, project structure tree (security table reordered alphabetically: gitleaks → pip-audit → semgrep → trivy)

## Test plan

- [x] `bats tests/security/pip-audit.bats` — 4/4 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #15