### PR TITLE
[FEATURE] Add bundler-audit CI snippet

### DIFF
--- a/CI/security/bundler-audit.yml
+++ b/CI/security/bundler-audit.yml
@@ -1,0 +1,35 @@
+bundler-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
+
+    - name: Install bundler-audit
+      run: gem install bundler-audit -v 0.9.2
+
+    - name: Run bundler-audit
+      run: |
+        set -euo pipefail
+
+        if ! command -v bundle-audit &> /dev/null; then
+          echo "::error::bundle-audit not found. Install it before running this script."
+          exit 1
+        fi
+
+        if [[ ! -f "Gemfile.lock" ]]; then
+          echo "::error::No Gemfile.lock found. Run 'bundle install' to generate one."
+          exit 1
+        fi
+
+        echo "ℹ️ Running bundle-audit..."
+
+        bundle-audit update
+        if bundle-audit check; then
+          echo "✅ bundler-audit passed"
+        else
+          echo "❌ bundler-audit found vulnerabilities"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ that projects compose into their own workflows.
 
 | Tool | Category | File |
 |------|----------|------|
+| bundler-audit | security | [CI/security/bundler-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/bundler-audit.yml) |
 | gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
 | pip-audit | security | [CI/security/pip-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/pip-audit.yml) |
 | semgrep | security | [CI/security/semgrep.yml](https://github.com/prog-time/workflows/blob/main/CI/security/semgrep.yml) |
@@ -92,6 +93,7 @@ Workflows/
 │   │   │   ├── tflint.yml
 │   │   │   └── yamllint.yml
 │   │   ├── security/
+│   │   │   ├── bundler-audit.yml
 │   │   │   ├── gitleaks.yml
 │   │   │   ├── pip-audit.yml
 │   │   │   ├── semgrep.yml
@@ -127,6 +129,7 @@ Workflows/
 │       │   ├── tflint.sh
 │       │   └── yamllint.sh
 │       ├── security/
+│       │   ├── bundler-audit.sh
 │       │   ├── gitleaks.sh
 │       │   ├── pip-audit.sh
 │       │   ├── semgrep.sh
@@ -154,6 +157,7 @@ Workflows/
 │   │   ├── tflint.bats
 │   │   └── yamllint.bats
 │   ├── security/
+│   │   ├── bundler-audit.bats
 │   │   ├── gitleaks.bats
 │   │   ├── pip-audit.bats
 │   │   ├── semgrep.bats
@@ -232,6 +236,7 @@ shellcheck:
 
 | Snippet | Tool | What it checks |
 |---------|------|----------------|
+| `CI/security/bundler-audit.yml` | [bundler-audit](https://github.com/rubysec/bundler-audit) | CVEs in Ruby gem dependencies via the Ruby Advisory Database |
 | `CI/security/gitleaks.yml` | [gitleaks](https://github.com/gitleaks/gitleaks) | Hardcoded secrets, tokens, and API keys |
 | `CI/security/pip-audit.yml` | [pip-audit](https://github.com/pypa/pip-audit) | CVEs in Python dependencies via the PyPI Advisory Database |
 | `CI/security/semgrep.yml` | [semgrep](https://semgrep.dev) | OWASP Top 10 patterns and insecure coding patterns across Python, JS/TS, Go, Java, Ruby, and more |

--- a/scripts/CI/security/bundler-audit.yml
+++ b/scripts/CI/security/bundler-audit.yml
@@ -1,0 +1,14 @@
+bundler-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
+
+    - name: Install bundler-audit
+      run: gem install bundler-audit -v 0.9.2
+
+    - name: Run bundler-audit
+      run: bash scripts/shell/security/bundler-audit.sh

--- a/scripts/shell/security/bundler-audit.sh
+++ b/scripts/shell/security/bundler-audit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v bundle-audit &> /dev/null; then
+  echo "::error::bundle-audit not found. Install it before running this script."
+  exit 1
+fi
+
+if [[ ! -f "Gemfile.lock" ]]; then
+  echo "::error::No Gemfile.lock found. Run 'bundle install' to generate one."
+  exit 1
+fi
+
+echo "ℹ️ Running bundle-audit..."
+
+bundle-audit update
+if bundle-audit check; then
+  echo "✅ bundler-audit passed"
+else
+  echo "❌ bundler-audit found vulnerabilities"
+  exit 1
+fi

--- a/tests/security/bundler-audit.bats
+++ b/tests/security/bundler-audit.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/bundler-audit.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_bundle_audit_stub() {
+  local check_exit_code="$1"
+  cat > "$TEST_DIR/bin/bundle-audit" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "check" ]]; then
+  exit $check_exit_code
+fi
+# update and other subcommands succeed
+exit 0
+EOF
+  chmod +x "$TEST_DIR/bin/bundle-audit"
+}
+
+@test "bundle-audit not installed: exits 1 with error annotation" {
+  # Do not create a bundle-audit stub — it should be absent from PATH
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::bundle-audit not found"* ]]
+}
+
+@test "no Gemfile.lock present: exits 1 with error annotation" {
+  make_bundle_audit_stub 0
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No Gemfile.lock found"* ]]
+}
+
+@test "clean Gemfile.lock: exits 0 with success message" {
+  make_bundle_audit_stub 0
+  touch "$TEST_DIR/Gemfile.lock"
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ bundler-audit passed"* ]]
+}
+
+@test "vulnerable gem in Gemfile.lock: exits 1 with failure message" {
+  make_bundle_audit_stub 1
+  touch "$TEST_DIR/Gemfile.lock"
+  cd "$TEST_DIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ bundler-audit found vulnerabilities"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a bundler-audit CI snippet to the `security` category — the Ruby counterpart to pip-audit. Cross-references gems pinned in `Gemfile.lock` against the `ruby-advisory-db`. Uses `ruby/setup-ruby@v1` (Ruby 3.3) + pinned `bundler-audit 0.9.2`.

## Changes

- `issues-16|add bundler-audit CI snippet` — `scripts/shell/security/bundler-audit.sh`, `scripts/CI/security/bundler-audit.yml`, `CI/security/bundler-audit.yml`
- `issues-16|add BATS tests for bundler-audit` — 4 tests (missing binary, missing `Gemfile.lock`, clean, vulnerable gem)
- `issues-16|document bundler-audit in README` — snippets table, Available snippets / Security section, project structure tree

## Test plan

- [x] `bats tests/security/bundler-audit.bats` — 4/4 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #16