### PR TITLE
[FEATURE] Add cargo test CI snippet

### DIFF
--- a/CI/tests/cargo_test.yml
+++ b/CI/tests/cargo_test.yml
@@ -1,0 +1,31 @@
+cargo_test:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Cargo registry and target
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Run cargo test
+      run: |
+        set -euo pipefail
+
+        if [[ ! -f "Cargo.toml" ]]; then
+          echo "::error::No Cargo.toml found"
+          exit 1
+        fi
+
+        echo "ℹ️ Running cargo test..."
+        cargo test --all-features --verbose \
+          && echo "✅ cargo tests passed" \
+          || { echo "❌ cargo tests failed"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ that projects compose into their own workflows.
 | SpotBugs | static_analysis | [CI/static_analysis/spotbugs.yml](https://github.com/prog-time/workflows/blob/main/CI/static_analysis/spotbugs.yml) |
 | mermaid-cli | build | [CI/build/mermaid.yml](https://github.com/prog-time/workflows/blob/main/CI/build/mermaid.yml) |
 | BATS | tests | [CI/tests/bats.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/bats.yml) |
+| cargo test | tests | [CI/tests/cargo_test.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/cargo_test.yml) |
 | go test | tests | [CI/tests/go_test.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/go_test.yml) |
 | Jest | tests | [CI/tests/jest.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/jest.yml) |
 | Laravel | tests | [CI/tests/laravel_tests.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/laravel_tests.yml) |
@@ -104,6 +105,7 @@ Workflows/
 │   │   │   └── spotbugs.yml
 │   │   └── tests/
 │   │       ├── bats.yml
+│   │       ├── cargo_test.yml
 │   │       ├── go_test.yml
 │   │       ├── jest.yml
 │   │       ├── laravel_tests.yml
@@ -135,6 +137,7 @@ Workflows/
 │       │   ├── semgrep.sh
 │       │   └── trivy.sh
 │       └── tests/
+│           ├── cargo_test.sh
 │           └── jest.sh
 │
 ├── CI/                             # assembled output (ready to use)
@@ -163,6 +166,7 @@ Workflows/
 │   │   ├── semgrep.bats
 │   │   └── trivy.bats
 │   ├── tests/
+│   │   ├── cargo_test.bats
 │   │   └── jest.bats
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
@@ -277,6 +281,7 @@ shellcheck:
 | Snippet | What it runs |
 |---------|--------------|
 | `CI/tests/bats.yml` | BATS tests (`tests/` directory) |
+| `CI/tests/cargo_test.yml` | Rust test suite (`cargo test --all-features --verbose`) |
 | `CI/tests/go_test.yml` | Go test suite (`go test ./...`) |
 | `CI/tests/jest.yml` | JavaScript/TypeScript test suite (Jest) |
 | `CI/tests/laravel_tests.yml` | Laravel test suite (PHP 8.2, SQLite, parallel) |

--- a/scripts/CI/tests/cargo_test.yml
+++ b/scripts/CI/tests/cargo_test.yml
@@ -1,0 +1,20 @@
+cargo_test:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Cargo registry and target
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Run cargo test
+      run: bash scripts/shell/tests/cargo_test.sh

--- a/scripts/shell/tests/cargo_test.sh
+++ b/scripts/shell/tests/cargo_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f "Cargo.toml" ]]; then
+  echo "::error::No Cargo.toml found"
+  exit 1
+fi
+
+echo "ℹ️ Running cargo test..."
+cargo test --all-features --verbose \
+  && echo "✅ cargo tests passed" \
+  || { echo "❌ cargo tests failed"; exit 1; }

--- a/tests/tests/cargo_test.bats
+++ b/tests/tests/cargo_test.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/tests/cargo_test.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_cargo_stub() {
+  local exit_code="$1"
+  cat > "$TEST_DIR/bin/cargo" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$TEST_DIR/bin/cargo"
+}
+
+@test "no Cargo.toml: exits 1 with error annotation" {
+  make_cargo_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No Cargo.toml found"* ]]
+}
+
+@test "Cargo.toml present, tests pass: exits 0 with success message" {
+  make_cargo_stub 0
+  touch Cargo.toml
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ cargo tests passed"* ]]
+}
+
+@test "Cargo.toml present, tests fail: exits 1 with failure message" {
+  make_cargo_stub 1
+  touch Cargo.toml
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ cargo tests failed"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a `cargo test` CI snippet to the `tests` category — the Rust counterpart to `clippy` (PR #25), closing the Rust test gap and mirroring the structure of `go test`, `pytest`, and `rspec`. Uses `dtolnay/rust-toolchain@stable` + `actions/cache@v4` for `~/.cargo/registry` and `target/` keyed on `Cargo.lock`. Runs `cargo test --all-features --verbose`.

## Changes

- `issues-17|add cargo test CI snippet` — `scripts/shell/tests/cargo_test.sh`, `scripts/CI/tests/cargo_test.yml`, `CI/tests/cargo_test.yml`
- `issues-17|add BATS tests for cargo test` — 3 tests (missing Cargo.toml, passing, failing)
- `issues-17|document cargo test in README` — snippets table, Available snippets / Tests section, project structure tree

## Test plan

- [x] `bats tests/tests/cargo_test.bats` — 3/3 pass
- [x] `yamllint` clean on both new YAML files
- [ ] CI green on this PR

Closes #17