### PR TITLE
Add xcodebuild test CI snippet

### DIFF
--- a/CI/tests/xcodebuild_test.yml
+++ b/CI/tests/xcodebuild_test.yml
@@ -1,0 +1,72 @@
+xcodebuild_test:
+  runs-on: macos-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Select Xcode version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Install xcpretty
+      run: gem install xcpretty
+
+    - name: Run xcodebuild test
+      run: |
+        set -euo pipefail
+
+        # Guard: xcodebuild must be present
+        if ! command -v xcodebuild &>/dev/null; then
+          echo "::error::xcodebuild not found — this job must run on macos-latest"
+          exit 1
+        fi
+
+        # Guard: xcpretty must be present
+        if ! command -v xcpretty &>/dev/null; then
+          echo "::error::xcpretty not found — run: gem install xcpretty"
+          exit 1
+        fi
+
+        # Locate workspace or project at repo root (bash-3.2-safe — no mapfile)
+        workspace_count=0
+        project_count=0
+        found_path=""
+
+        for f in *.xcworkspace; do
+          [ -e "$f" ] || continue
+          workspace_count=$((workspace_count + 1))
+          found_path="$f"
+        done
+
+        for f in *.xcodeproj; do
+          [ -e "$f" ] || continue
+          project_count=$((project_count + 1))
+          found_path="$f"
+        done
+
+        total_count=$((workspace_count + project_count))
+
+        if [ "$total_count" -eq 0 ]; then
+          echo "::error::No Xcode workspace or project found"
+          exit 1
+        fi
+
+        if [ "$total_count" -gt 1 ]; then
+          echo "::error::Multiple Xcode workspaces/projects found (specify via SCHEME/PROJECT env)"
+          exit 1
+        fi
+
+        # Resolve scheme: honour env var, fall back to basename without extension
+        if [ -z "${SCHEME:-}" ]; then
+          basename_no_ext="${found_path%.*}"
+          SCHEME="$basename_no_ext"
+        fi
+
+        echo "ℹ️ Running xcodebuild test — scheme: $SCHEME"
+
+        xcodebuild test \
+          -scheme "$SCHEME" \
+          -destination 'platform=iOS Simulator,name=iPhone 15' \
+          | xcpretty \
+          && echo "✅ xcodebuild tests passed" \
+          || { echo "❌ xcodebuild tests failed"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ shellcheck:
 | `CI/tests/laravel_tests.yml` | Laravel test suite (PHP 8.2, SQLite, parallel) |
 | `CI/tests/pytest.yml` | Python test suite (pytest) |
 | `CI/tests/rspec.yml` | Ruby test suite (RSpec via Bundler) |
-| `CI/tests/xcodebuild_test.yml` | Swift/iOS XCTest suite (`xcodebuild test` via xcpretty) — **must run on `macos-latest`** |
+| `CI/tests/xcodebuild_test.yml` | Swift/iOS XCTest suite (`xcodebuild test` via xcpretty) — **macOS only** |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ that projects compose into their own workflows.
 | Laravel | tests | [CI/tests/laravel_tests.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/laravel_tests.yml) |
 | pytest | tests | [CI/tests/pytest.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/pytest.yml) |
 | RSpec | tests | [CI/tests/rspec.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/rspec.yml) |
+| xcodebuild test | tests | [CI/tests/xcodebuild_test.yml](https://github.com/prog-time/workflows/blob/main/CI/tests/xcodebuild_test.yml) (**macos-latest**) |
 
 ---
 
@@ -110,7 +111,8 @@ Workflows/
 │   │       ├── jest.yml
 │   │       ├── laravel_tests.yml
 │   │       ├── pytest.yml
-│   │       └── rspec.yml
+│   │       ├── rspec.yml
+│   │       └── xcodebuild_test.yml
 │   └── shell/                      # bash scripts (one per tool)
 │       ├── linters/
 │       │   ├── clippy.sh
@@ -138,7 +140,8 @@ Workflows/
 │       │   └── trivy.sh
 │       └── tests/
 │           ├── cargo_test.sh
-│           └── jest.sh
+│           ├── jest.sh
+│           └── xcodebuild_test.sh
 │
 ├── CI/                             # assembled output (ready to use)
 │   ├── linters/
@@ -167,7 +170,8 @@ Workflows/
 │   │   └── trivy.bats
 │   ├── tests/
 │   │   ├── cargo_test.bats
-│   │   └── jest.bats
+│   │   ├── jest.bats
+│   │   └── xcodebuild_test.bats
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
 │
@@ -287,6 +291,7 @@ shellcheck:
 | `CI/tests/laravel_tests.yml` | Laravel test suite (PHP 8.2, SQLite, parallel) |
 | `CI/tests/pytest.yml` | Python test suite (pytest) |
 | `CI/tests/rspec.yml` | Ruby test suite (RSpec via Bundler) |
+| `CI/tests/xcodebuild_test.yml` | Swift/iOS XCTest suite (`xcodebuild test` via xcpretty) — **must run on `macos-latest`** |
 
 ---
 

--- a/scripts/CI/tests/xcodebuild_test.yml
+++ b/scripts/CI/tests/xcodebuild_test.yml
@@ -1,0 +1,15 @@
+xcodebuild_test:
+  runs-on: macos-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Select Xcode version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Install xcpretty
+      run: gem install xcpretty
+
+    - name: Run xcodebuild test
+      run: bash scripts/shell/tests/xcodebuild_test.sh

--- a/scripts/shell/tests/xcodebuild_test.sh
+++ b/scripts/shell/tests/xcodebuild_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard: xcodebuild must be present
+if ! command -v xcodebuild &>/dev/null; then
+  echo "::error::xcodebuild not found — this job must run on macos-latest"
+  exit 1
+fi
+
+# Guard: xcpretty must be present
+if ! command -v xcpretty &>/dev/null; then
+  echo "::error::xcpretty not found — run: gem install xcpretty"
+  exit 1
+fi
+
+# Locate workspace or project at repo root (bash-3.2-safe — no mapfile)
+workspace_count=0
+project_count=0
+found_path=""
+
+for f in *.xcworkspace; do
+  [ -e "$f" ] || continue
+  workspace_count=$((workspace_count + 1))
+  found_path="$f"
+done
+
+for f in *.xcodeproj; do
+  [ -e "$f" ] || continue
+  project_count=$((project_count + 1))
+  found_path="$f"
+done
+
+total_count=$((workspace_count + project_count))
+
+if [ "$total_count" -eq 0 ]; then
+  echo "::error::No Xcode workspace or project found"
+  exit 1
+fi
+
+if [ "$total_count" -gt 1 ]; then
+  echo "::error::Multiple Xcode workspaces/projects found (specify via SCHEME/PROJECT env)"
+  exit 1
+fi
+
+# Resolve scheme: honour env var, fall back to basename without extension
+if [ -z "${SCHEME:-}" ]; then
+  basename_no_ext="${found_path%.*}"
+  SCHEME="$basename_no_ext"
+fi
+
+echo "ℹ️ Running xcodebuild test — scheme: $SCHEME"
+
+xcodebuild test \
+  -scheme "$SCHEME" \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  | xcpretty \
+  && echo "✅ xcodebuild tests passed" \
+  || { echo "❌ xcodebuild tests failed"; exit 1; }

--- a/tests/tests/xcodebuild_test.bats
+++ b/tests/tests/xcodebuild_test.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/tests/xcodebuild_test.sh"
+
+setup() {
+  setup_test_dir
+  mkdir -p "$TEST_DIR/bin"
+  export PATH="$TEST_DIR/bin:$PATH"
+
+  # Stub xcodebuild and xcpretty so the guards pass in structural tests
+  cat > "$TEST_DIR/bin/xcodebuild" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$TEST_DIR/bin/xcodebuild"
+
+  cat > "$TEST_DIR/bin/xcpretty" <<'EOF'
+#!/usr/bin/env bash
+cat
+EOF
+  chmod +x "$TEST_DIR/bin/xcpretty"
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+@test "no workspace or project: exits 1 with no-project error" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No Xcode workspace or project found"* ]]
+}
+
+@test "two workspaces present: exits 1 with disambiguation error" {
+  mkdir -p "App.xcworkspace" "Other.xcworkspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::Multiple Xcode workspaces/projects found"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a Swift/iOS test runner snippet to the `tests` category, parallel to `cargo_test`, `pytest`, and `rspec`. The job runs on `macos-latest` because `xcodebuild` is macOS-only.

## Changes

- `scripts/shell/tests/xcodebuild_test.sh` — bash runner: guards `xcodebuild`/`xcpretty`, detects a single `*.xcworkspace`/`*.xcodeproj`, resolves the scheme (env `SCHEME` → basename), runs `xcodebuild test | xcpretty`.
- `scripts/CI/tests/xcodebuild_test.yml` — source snippet: `runs-on: macos-latest`, `actions/checkout@v4`, `maxim-lobanov/setup-xcode@v1`, `gem install xcpretty`, then the runner.
- `CI/tests/xcodebuild_test.yml` — assembled output.
- `tests/tests/xcodebuild_test.bats` — structural tests: no-project → exit 1, multiple workspaces → exit 1. `xcodebuild`/`xcpretty` are stubbed on PATH.
- `README.md` — new row in the tests table with the `macos-latest` note, plus entries in the file tree and appendix.

Closes #18