### PR TITLE
Add Dependabot config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,13 @@ Workflows/
 │   │   ├── cargo_test.bats
 │   │   ├── jest.bats
 │   │   └── xcodebuild_test.bats
+│   ├── dependabot/
+│   │   └── dependabot.bats         # validates the Dependabot template
 │   └── helpers/
 │       └── common.bash             # shared test utilities (mocks, temp dirs)
+│
+├── dependabot/
+│   └── dependabot.yml              # Dependabot config template (copy to .github/)
 │
 └── rules/                          # living documentation for contributors
     ├── README.md
@@ -320,6 +325,31 @@ jobs:
   phpstan:           # paste content of CI/static_analysis/phpstan.yml here
     ...
 ```
+
+---
+
+## Dependabot template
+
+`dependabot/dependabot.yml` is a ready-to-copy [Dependabot](https://docs.github.com/en/code-security/dependabot)
+configuration template. Unlike the CI snippets in `CI/`, this file is not a GitHub Actions job — it is a
+repository-level configuration that GitHub reads natively from `.github/dependabot.yml`.
+
+**This artefact does not follow the three-layer pattern** (`shell → source YAML → assembled YAML`). There is
+no shell script or assembler step. Copy the file directly into your project's `.github/` directory.
+
+### Usage
+
+```bash
+cp dependabot/dependabot.yml <your-project>/.github/dependabot.yml
+```
+
+The template enables weekly automated dependency-update PRs for seven ecosystems:
+`github-actions`, `npm`, `pip`, `bundler`, `composer`, `cargo`, and `gomod`.
+Each entry uses `open-pull-requests-limit: 5` and a stable `commit-message` prefix so the
+resulting PRs are easy to filter and review.
+
+Adjust the `directory` field per entry if your dependency manifests live in a subdirectory
+rather than the repository root.
 
 ---
 

--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"

--- a/tests/dependabot/dependabot.bats
+++ b/tests/dependabot/dependabot.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+TEMPLATE="$BATS_TEST_DIRNAME/../../dependabot/dependabot.yml"
+
+@test "file parses as valid YAML" {
+  run yamllint "$TEMPLATE"
+  [ "$status" -eq 0 ]
+}
+
+@test "version is 2" {
+  grep -q "^version: 2$" "$TEMPLATE"
+}
+
+@test "all required ecosystems are present" {
+  grep -q "package-ecosystem: \"github-actions\"" "$TEMPLATE"
+  grep -q "package-ecosystem: \"npm\""            "$TEMPLATE"
+  grep -q "package-ecosystem: \"pip\""            "$TEMPLATE"
+  grep -q "package-ecosystem: \"bundler\""        "$TEMPLATE"
+  grep -q "package-ecosystem: \"composer\""       "$TEMPLATE"
+  grep -q "package-ecosystem: \"cargo\""          "$TEMPLATE"
+  grep -q "package-ecosystem: \"gomod\""          "$TEMPLATE"
+}
+
+@test "every entry has schedule.interval set" {
+  ecosystem_count=$(grep -c "package-ecosystem:" "$TEMPLATE")
+  interval_count=$(grep -c "interval:" "$TEMPLATE")
+  [ "$interval_count" -eq "$ecosystem_count" ]
+}


### PR DESCRIPTION
## Summary

Adds a shareable Dependabot configuration template that downstream projects copy into their `.github/` directory. This artefact is a repository-level GitHub config, not a CI job, so it intentionally sits outside the `shell → source YAML → assembled YAML` three-layer pattern used elsewhere.

## Changes

- `dependabot/dependabot.yml` — `version: 2`, weekly schedule, `open-pull-requests-limit: 5`, stable commit-message prefixes. Covers seven ecosystems: `github-actions`, `npm`, `pip`, `bundler`, `composer`, `cargo`, `gomod`.
- `tests/dependabot/dependabot.bats` — structural BATS tests: YAML parse validity (via `yamllint`), `version: 2`, presence of all seven required ecosystems, one `schedule.interval` per ecosystem.
- `README.md` — new top-level "Dependabot template" section with usage (`cp` command), the "not a CI job" note, and the ecosystem list; project-structure tree updated with `dependabot/` and `tests/dependabot/`.

## Notes

- No `rules/` update needed — the "not three-layer" exception is explained inline in the new README section.
- Lint status: `markdownlint README.md CONTRIBUTING.md` clean locally; line lengths stay under the MD013 limit (120).

Closes #19