### PR TITLE
issues-35 | Add composer-audit security snippet

### DIFF
--- a/CI/security/composer-audit.yml
+++ b/CI/security/composer-audit.yml
@@ -1,0 +1,42 @@
+composer-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "8.2"
+
+    - name: Cache Composer
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: composer-${{ hashFiles('composer.lock') }}
+        restore-keys: composer-
+
+    - name: Install dependencies
+      run: composer install --no-interaction --prefer-dist
+
+    - name: Run composer-audit
+      run: |
+        set -euo pipefail
+
+        if ! command -v composer &> /dev/null; then
+          echo "::error::composer not found. Install it before running this script."
+          exit 1
+        fi
+
+        if [[ ! -f "composer.lock" ]]; then
+          echo "::error::No composer.lock found. Run 'composer install' to generate one."
+          exit 1
+        fi
+
+        echo "ℹ️ Running composer audit..."
+
+        if composer audit --abandoned=ignore; then
+          echo "✅ composer-audit passed"
+        else
+          echo "❌ composer-audit found vulnerabilities"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ that projects compose into their own workflows.
 | Tool | Category | File |
 |------|----------|------|
 | bundler-audit | security | [CI/security/bundler-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/bundler-audit.yml) |
+| composer-audit | security | [CI/security/composer-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/composer-audit.yml) |
 | gitleaks | security | [CI/security/gitleaks.yml](https://github.com/prog-time/workflows/blob/main/CI/security/gitleaks.yml) |
 | pip-audit | security | [CI/security/pip-audit.yml](https://github.com/prog-time/workflows/blob/main/CI/security/pip-audit.yml) |
 | semgrep | security | [CI/security/semgrep.yml](https://github.com/prog-time/workflows/blob/main/CI/security/semgrep.yml) |

--- a/scripts/CI/security/composer-audit.yml
+++ b/scripts/CI/security/composer-audit.yml
@@ -1,0 +1,22 @@
+composer-audit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "8.2"
+
+    - name: Cache Composer
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: composer-${{ hashFiles('composer.lock') }}
+        restore-keys: composer-
+
+    - name: Install dependencies
+      run: composer install --no-interaction --prefer-dist
+
+    - name: Run composer-audit
+      run: bash scripts/shell/security/composer-audit.sh

--- a/scripts/shell/security/composer-audit.sh
+++ b/scripts/shell/security/composer-audit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v composer &> /dev/null; then
+  echo "::error::composer not found. Install it before running this script."
+  exit 1
+fi
+
+if [[ ! -f "composer.lock" ]]; then
+  echo "::error::No composer.lock found. Run 'composer install' to generate one."
+  exit 1
+fi
+
+echo "ℹ️ Running composer audit..."
+
+if composer audit --abandoned=ignore; then
+  echo "✅ composer-audit passed"
+else
+  echo "❌ composer-audit found vulnerabilities"
+  exit 1
+fi

--- a/tests/security/composer-audit.bats
+++ b/tests/security/composer-audit.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/security/composer-audit.sh"
+
+setup() {
+  setup_test_dir
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_composer_stub() {
+  local audit_exit_code="$1"
+  mkdir -p "$TEST_DIR/bin"
+  cat > "$TEST_DIR/bin/composer" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "audit" ]]; then
+  exit $audit_exit_code
+fi
+exit 0
+STUB
+  chmod +x "$TEST_DIR/bin/composer"
+  export PATH="$TEST_DIR/bin:$PATH"
+}
+
+@test "composer not installed: exits 1 with error annotation" {
+  PATH="/usr/bin:/bin" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::composer not found"* ]]
+}
+
+@test "no composer.lock present: exits 1 with error annotation" {
+  make_composer_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::No composer.lock found"* ]]
+}
+
+@test "clean composer.lock: exits 0 with success message" {
+  make_composer_stub 0
+  touch "$TEST_DIR/composer.lock"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ composer-audit passed"* ]]
+}
+
+@test "vulnerable dependency: exits 1 with failure message" {
+  make_composer_stub 1
+  touch "$TEST_DIR/composer.lock"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ composer-audit found vulnerabilities"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a `composer-audit` snippet to the **security** category — scans PHP/Composer dependencies for known vulnerabilities (CVEs) via `composer audit`.

Fills an obvious gap: the catalog already ships dependency-audit for Ruby (`bundler-audit`) and Python (`pip-audit`), but had no PHP/Composer equivalent. On a real Laravel project this immediately surfaces vulnerable transitive deps (e.g. a CVE in `symfony/yaml`).

## Changes (follows the standard snippet convention)

- `scripts/shell/security/composer-audit.sh` — `set -euo pipefail`; guards presence of `composer` and `composer.lock` with `::error::`; runs `composer audit --abandoned=ignore` (fails only on real advisories, not abandoned-package noise).
- `tests/security/composer-audit.bats` — covers: composer missing, no `composer.lock`, clean lock, vulnerable dependency (mirrors `bundler-audit.bats`).
- `scripts/CI/security/composer-audit.yml` — source job (`run: bash scripts/shell/security/composer-audit.sh`).
- `CI/security/composer-audit.yml` — assembled output.
- `README.md` — new row in the snippet catalog table.

## Verification

- `bats tests/security/composer-audit.bats` → 4/4 pass.
- `bash scripts/assemble-ci.sh scripts/CI/security scripts/shell/security CI/security` regenerates cleanly — existing `CI/security/*.yml` unchanged (`git diff` on them empty); only the new file added.
- `markdownlint README.md` → clean.

Closes #35

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._