### PR TITLE
issues-37 | Add Pint linter snippet

### DIFF
--- a/CI/linters/pint.yml
+++ b/CI/linters/pint.yml
@@ -1,0 +1,41 @@
+pint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "8.2"
+
+    - name: Cache Composer
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: composer-${{ hashFiles('composer.lock') }}
+        restore-keys: composer-
+
+    - name: Install dependencies
+      run: composer install --no-interaction --prefer-dist
+
+    - name: Run pint
+      run: |
+        set -euo pipefail
+
+        if [[ -x "vendor/bin/pint" ]]; then
+          PINT="vendor/bin/pint"
+        elif command -v pint &> /dev/null; then
+          PINT="pint"
+        else
+          echo "::error::laravel/pint not found (run 'composer require --dev laravel/pint')"
+          exit 1
+        fi
+
+        echo "ℹ️ Running Pint in check mode..."
+
+        if "$PINT" --test; then
+          echo "✅ pint passed"
+        else
+          echo "❌ pint found style issues"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ that projects compose into their own workflows.
 | markdownlint | linters | [CI/linters/markdownlint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/markdownlint.yml) |
 | mermaid-cli | linters | [CI/linters/mermaid.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/mermaid.yml) |
 | phpcs | linters | [CI/linters/phpcs.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/phpcs.yml) |
+| Pint | linters | [CI/linters/pint.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/pint.yml) |
 | RuboCop | linters | [CI/linters/rubocop.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/rubocop.yml) |
 | Ruff | linters | [CI/linters/ruff.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/ruff.yml) |
 | ShellCheck | linters | [CI/linters/shellcheck.yml](https://github.com/prog-time/workflows/blob/main/CI/linters/shellcheck.yml) |

--- a/scripts/CI/linters/pint.yml
+++ b/scripts/CI/linters/pint.yml
@@ -1,0 +1,22 @@
+pint:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "8.2"
+
+    - name: Cache Composer
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: composer-${{ hashFiles('composer.lock') }}
+        restore-keys: composer-
+
+    - name: Install dependencies
+      run: composer install --no-interaction --prefer-dist
+
+    - name: Run pint
+      run: bash scripts/shell/linters/pint.sh

--- a/scripts/shell/linters/pint.sh
+++ b/scripts/shell/linters/pint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -x "vendor/bin/pint" ]]; then
+  PINT="vendor/bin/pint"
+elif command -v pint &> /dev/null; then
+  PINT="pint"
+else
+  echo "::error::laravel/pint not found (run 'composer require --dev laravel/pint')"
+  exit 1
+fi
+
+echo "ℹ️ Running Pint in check mode..."
+
+if "$PINT" --test; then
+  echo "✅ pint passed"
+else
+  echo "❌ pint found style issues"
+  exit 1
+fi

--- a/tests/linters/pint.bats
+++ b/tests/linters/pint.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load "../helpers/common"
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/shell/linters/pint.sh"
+
+setup() {
+  setup_test_dir
+}
+
+teardown() {
+  teardown_test_dir
+}
+
+make_pint_stub() {
+  local exit_code="$1"
+  mkdir -p "$TEST_DIR/vendor/bin"
+  cat > "$TEST_DIR/vendor/bin/pint" <<STUB
+#!/usr/bin/env bash
+exit $exit_code
+STUB
+  chmod +x "$TEST_DIR/vendor/bin/pint"
+}
+
+@test "pint not installed: exits 1 with error annotation" {
+  PATH="/usr/bin:/bin" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::laravel/pint not found"* ]]
+}
+
+@test "clean code: exits 0 with success message" {
+  make_pint_stub 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅ pint passed"* ]]
+}
+
+@test "style issues: exits 1 with failure message" {
+  make_pint_stub 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"❌ pint found style issues"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a `pint` snippet to the **linters** category — Laravel/PHP code-style check via `vendor/bin/pint --test`.

The catalog ships `phpcs`, but the de-facto standard in Laravel projects is **Laravel Pint** (PHP-CS-Fixer wrapper, PSR-12 + Laravel preset). Direct sibling of `rubocop`/`ruff`. Pint needs no mandatory config (`pint.json` is optional), so the script guards on the binary, not a config file.

## Changes (standard snippet convention)

- `scripts/shell/linters/pint.sh` — `set -euo pipefail`; resolves `vendor/bin/pint` or `pint` on PATH, else `::error::`; runs `pint --test` (check-only, no auto-fix).
- `tests/linters/pint.bats` — covers: pint not installed, clean code, style issues.
- `scripts/CI/linters/pint.yml` — source job.
- `CI/linters/pint.yml` — assembled output.
- `README.md` — new catalog row.

## Verification

- `bats tests/linters/pint.bats` → 3/3 pass.
- `assemble-ci.sh` regenerates cleanly — existing `CI/linters/*.yml` unchanged; only the new file added.
- `markdownlint README.md` → clean.

Closes #37

---

_The task was generated using the MCP server — [prog-time/mcp-github-issues](https://github.com/prog-time/mcp-github-issues)._